### PR TITLE
Fix #12: Adjust collection dates on the current day - only add a year if the date is over 7 days ago (not <= today)

### DIFF
--- a/time.go
+++ b/time.go
@@ -10,8 +10,8 @@ func adjustYear(t time.Time) time.Time {
 	today := now()
 	thisYear := today.Year()
 	t = t.AddDate(thisYear, 0, 0)
-	// year correction
-	if t.Before(today) && today.Format("20060102") != t.Format("20060102") {
+	// year correction if date is over a week ago
+	if t.Before(today.AddDate(0, 0, -7)) && today.Format("20060102") != t.Format("20060102") {
 		t = t.AddDate(1, 0, 0)
 	}
 	return t


### PR DESCRIPTION
Fix #12 

This fixed the issue I experienced today. I deployed the updated container and now my rubbish collection date is accurate (today instead of 1 year from now.)

<img width="568" alt="Screenshot 2024-07-04 at 2 20 50 PM" src="https://github.com/rusq/aklapi/assets/139536/3096257e-4813-4799-bce0-a81b08604018">

<img width="670" alt="Screenshot 2024-07-04 at 2 20 00 PM" src="https://github.com/rusq/aklapi/assets/139536/adf1ca96-de37-4642-bbce-47a838b4e02d">

Thanks for all your work on this project, it's really cool to have these sensors in my HA dashboard.